### PR TITLE
remove -u from go get staticcheck

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Get dependencies
-      run: go get -u honnef.co/go/tools/cmd/staticcheck@latest
+      run: go get honnef.co/go/tools/cmd/staticcheck@latest
 
     - name: Check
       run: make check


### PR DESCRIPTION
The -u was causing the following:

```
go vet ./...
../../../go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.1/purell.go:17:2: missing go.sum entry for module providing package 
```
We discovered this while addressing:
https://github.com/open-cluster-management/backlog/issues/16338